### PR TITLE
Fix/complaint1

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -6,6 +6,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContextFactory<TestAssignmentContext>();
 // Add services to the container.
 builder.Services.AddGrpc();
+builder.Services.AddGrpcReflection();
+
 
 var app = builder.Build();
 
@@ -13,5 +15,12 @@ var app = builder.Build();
 app.MapGrpcService<GreeterService>();
 app.MapGrpcService<FiboService>();
 app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
+
+IWebHostEnvironment env = app.Environment;
+
+if (env.IsDevelopment())
+{
+    app.MapGrpcReflectionService();
+}
 
 app.Run();

--- a/Services/FiboService.cs
+++ b/Services/FiboService.cs
@@ -17,7 +17,7 @@ namespace TestAssignmentGrcp.Services
 
         public override async Task<SequenceReply> GetFibonacci(PositionsRequest request, ServerCallContext context)
         {
-            var seq = (await GetFiboAsync(request.Position)).ToList() ?? new List<int>();
+            var seq = await GetFiboAsync(request.Position);
             var sReply = new SequenceReply();
             sReply.Sequence.AddRange(seq);
             return sReply;
@@ -29,10 +29,10 @@ namespace TestAssignmentGrcp.Services
                 count);
             using var context = factory.CreateDbContext();
             
-          var cash = await context.FiboNumbers.Where(t => t.Position <= count)
+          var cache = await context.FiboNumbers.Where(t => t.Position <= count)
                 .ToDictionaryAsync(t => t.Position);
-            List<int> result = cash.Select(t => t.Value.Number).ToList();
-            if (cash.Keys.Contains(count-1))
+            List<int> result = cache.OrderBy(t => t.Key).Select(t => t.Value.Number).ToList();
+            if (cache.ContainsKey(count-1))
             {
                 logger.LogInformation("{ServiceName}: Sequence for {count} position has already counted. Cash has been returned.", 
                     nameof(FiboService),
@@ -49,8 +49,8 @@ namespace TestAssignmentGrcp.Services
                 }
             }
             List<FiboNumber> newCash = new();
-            var toDb = result.Skip(cash.Keys.Count()).ToArray();
-            for (int i = cash.Keys.Count(); i < (toDb.Count()+cash.Keys.Count()); i++)
+            var toDb = result.Skip(cache.Keys.Count()).ToArray();
+            for (int i = cache.Keys.Count(); i < (toDb.Count()+ cache.Keys.Count()); i++)
             {
                 newCash.Add(
                     new FiboNumber { Number = result[i], 

--- a/Services/FiboService.cs
+++ b/Services/FiboService.cs
@@ -49,8 +49,8 @@ namespace TestAssignmentGrcp.Services
                 }
             }
             List<FiboNumber> newCash = new();
-            var toDb = result.Skip(cache.Keys.Count()).ToArray();
-            for (int i = cache.Keys.Count(); i < (toDb.Count()+ cache.Keys.Count()); i++)
+            var toDb = result.Skip(cache.Count()).ToArray();
+            for (int i = cache.Count(); i < (toDb.Count()+ cache.Count()); i++)
             {
                 newCash.Add(
                     new FiboNumber { Number = result[i], 

--- a/TestAssignmentGrcp.csproj
+++ b/TestAssignmentGrcp.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.57.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.63.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fix List:
- List<int> result = cash.Select(t => t.Value.Number).ToList(); add order
- var seq = (await GetFiboAsync(request.Position)).ToList() ?? new List<int>(); removed unused code
- work with dictionary directly when counting or check for key without use propety Key
- fix spelling cash to cache
- add gRCP reflection for dev environment